### PR TITLE
[ECO-155] Added mobbex subscriptions data to mobbex order widget

### DIFF
--- a/mobbex_subscriptions/classes/Execution.php
+++ b/mobbex_subscriptions/classes/Execution.php
@@ -77,4 +77,16 @@ class MobbexExecution extends \Mobbex\PS\Checkout\Models\Model
     ) {
         parent::__construct(...func_get_args());
     }
+
+    /**
+     * Get Mobbex execution from DB with the uid
+     * 
+     * @param int $uid
+     * @return array
+     */
+    public static function getData($uid)
+    {
+        $execution = \Db::getInstance()->executes('SELECT * FROM ' . _DB_PREFIX_ . 'mobbex_execution' . ' WHERE uid = "' . $uid . '";');
+        return !empty($execution[0]) ? json_decode($execution[0]['data'], true) : false;
+    }
 }

--- a/mobbex_subscriptions/classes/Subscriber.php
+++ b/mobbex_subscriptions/classes/Subscriber.php
@@ -215,4 +215,27 @@ class MobbexSubscriber extends \Mobbex\PS\Checkout\Models\Model
         // Remember, Mobbex returns an empty array on success edit
         return ($result || $result == []) && parent::save($null_values, $auto_date);
     }
+
+    /**
+     * Get Mobbex subscriber from DB with the cart id
+     * 
+     * @param int $cart_id
+     * @return object
+     */
+    public static function get($cart_id)
+    {
+        $subscriber = \Db::getInstance()->executes('SELECT * FROM ' . _DB_PREFIX_ . 'mobbex_subscriber' . ' WHERE cart_id = "' . $cart_id . '";');
+        return $subscriber[0];
+    }
+
+    /**
+     * Get subscriber execution from DB with the subscriber uid
+     * 
+     * @param int $subscriber_uid
+     * @return object
+     */
+    public static function getExecutions($subscriber_uid)
+    {
+        return \Db::getInstance()->executes('SELECT * FROM ' . _DB_PREFIX_ . 'mobbex_execution' . ' WHERE subscriber_uid = "' . $subscriber_uid . '" ORDER BY date DESC LIMIT 4;');
+    }
 }

--- a/mobbex_subscriptions/controllers/front/execution.php
+++ b/mobbex_subscriptions/controllers/front/execution.php
@@ -1,0 +1,49 @@
+<?php
+
+class Mobbex_SubscriptionsExecutionModuleFrontController extends \ModuleFrontController
+{
+    public function __construct()
+    {
+        parent::__construct();
+        $this->api    = new \Mobbex\Subscriptions\Api;
+        $this->config = new \Mobbex\PS\Checkout\Models\Config();
+        $this->logger = new \Mobbex\PS\Checkout\Models\Logger();
+    }
+
+    public function postProcess()
+    {
+        // We don't do anything if the module has been disabled by the merchant
+        if ($this->module->active == false)
+            $this->logger->log('fatal', 'Execution On Module Inactive (subscriptions endpoint)', $_REQUEST);
+
+        if (Tools::getValue('hash') !== md5($this->config->settings['api_key'] . '!' . $this->config->settings['access_token']))
+            $this->logger->log('fatal', 'Invalid hash in execution controller');
+
+        $subscriber   = Tools::getValue('subscriber');
+        $subscription = Tools::getValue('subscription');
+        $execution    = Tools::getValue('execution');
+        $url          = Tools::getValue('url');
+        
+        $data = [
+            'uri'    => "subscriptions/$subscription/subscriber/$subscriber/execution/$execution/action/retry",
+            'method' => 'GET',
+        ];
+
+        try {
+            //Retry execution
+            \Mobbex\Subscriptions\Api::request($data);
+            //Get execution data
+            $data  = \MobbexExecution::getData($execution);
+            $data['context']['status'] = "retried successfully";
+            $data  = json_encode($data);
+            //Update execution data in db
+            $query = "UPDATE `" . _DB_PREFIX_ . "mobbex_execution` SET data='$data' WHERE uid='$execution'";
+            Db::getInstance()->Execute($query);
+
+        } catch (\Mobbex\Subscriptions\Exception $e) {
+            $this->logger->log('fatal', 'execution > postProcess | Failed to retry subscription execute: '. $e->getMessage(), ['subscriber_uid' => $subscriber, 'subscription_uid' => $subscription, 'execution_uid' => $execution]);
+        }
+        
+        Tools::redirectAdmin($url);
+    }
+}

--- a/mobbex_subscriptions/views/order-widget.tpl
+++ b/mobbex_subscriptions/views/order-widget.tpl
@@ -1,0 +1,115 @@
+<tr>
+    <th>
+        <h3>Subscription Data</h3>
+    </th>
+</tr>
+<tr>
+    <td>Uid:</td>
+    <td>{$subscriber['subscription_uid']}</td>
+</tr>
+<tr class="mobbex-color-column">
+    <td>Start Date:</td>
+    <td>{$subscriber['start_date']}</td>
+</tr>
+<tr>
+    <td>Last Execution:</td>
+    <td>{$subscriber['last_execution']}</td>
+</tr>
+<tr class="mobbex-color-column">
+    <td>Next Execution:</td>
+    <td>{$subscriber['next_execution']}</td>
+</tr>
+
+<tr>
+    <th>
+        <h3>Subscriber Data</h3>
+    </th>
+</tr>
+<tr class="mobbex-color-column">
+    <td>Uid:</td>
+    <td>{$subscriber['uid']}</td>
+</tr>
+<tr>
+    <td>State:</td>
+    <td>{$subscriber['state']}</td>
+</tr>
+<tr class="mobbex-color-column">
+    <td>Test:</td>
+    <td>{$subscriber['test']}</td>
+</tr>
+<tr>
+    <td>Name:</td>
+    <td>{$subscriber['name']}</td>
+</tr>
+<tr class="mobbex-color-column">
+    <td>Email:</td>
+    <td>{$subscriber['email']}</td>
+</tr>
+<tr>
+    <td>phone:</td>
+    <td>{$subscriber['phone']}</td>
+<tr class="mobbex-color-column">
+    <td>Identification:</td>
+    <td>{$subscriber['identification']}</td>
+</tr>
+<tr>
+    <td>Customer id:</td>
+    <td>{$subscriber['customer_id']}</td>
+</tr>
+<tr class="mobbex-color-column">
+    <td>Source Url:</td>
+    <td><a href="{$subscriber['source_url']}">VER</a></td>
+</tr>
+<tr>
+    <td>Control Url:</td>
+    <td><a href="{$subscriber['control_url']}">VER</a></td>
+</tr>
+
+<tr>
+    <th>
+        <h3>Last Executions</h3>
+    </th>
+</tr>
+
+{foreach from=$executions item=execution}
+
+    <tr class="mobbex-color-column">
+        <td>Uid:</td>
+        <td>{$execution['execution']['uid']}</td>
+    </tr>
+    <tr>
+        <td>{l s='Execution Date:' mod='mobbex'}</td>
+        <td>{$execution['payment']['created']}</td>
+    </tr>
+    <tr class="mobbex-color-column">
+        <td>Status:</td>
+        <td>{$execution['context']['status']}</td>
+    </tr>
+    <tr>
+        <td>Used Source:</td>
+        <td>{$execution['execution']['source']}</td>
+    </tr>
+    <tr class="mobbex-color-column">
+        <td>Description:</td>
+        <td>{$execution['payment']['description']}</td>
+    </tr>
+
+    <tr class="mobbex-end-table">
+        {if $execution['payment']['status']['code'] >= 400 && $execution['context']['status'] !== 'retried successfully'} 
+            <th><a id="mobbex-retry" href="{$retryUrl}&subscriber={$subscriber['uid']}&subscription={$subscriber['subscription_uid']}&execution={$execution['execution']['uid']}&hash={$hash}&url={$returnUrl}">Retry Execution</a></th>
+        {/if}
+    </tr>
+
+{/foreach}
+
+{literal}
+    <style>
+        #mobbex-retry {
+            text-align: center;
+            padding: 2px 10px;
+            border-radius: 5px;
+            color: white;
+            background-color: #6f00ff;
+        }
+    </style>
+{/literal}


### PR DESCRIPTION
# Notas

* Añadida la información del suscriptor al widget de la orden.
* Añadida la información de la suscripción al widget de la orden.
* Añadida la información de las ultimas 4 ejecuciones al widget de la orden.
* Añadida la posibilidad de reintentar una ejecución fallida desde el widget de la orden.
* Requiere de los cambios añadidos en https://github.com/mobbexco/prestashop/pull/175 dentro del modulo principal.